### PR TITLE
Added basic usage to README.md + default port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,36 @@
-redis-server
-=======
+# redis-server
+
 Start a Redis server in Node.js like a boss.
+
 ## Installation
+
 ```npm install redis-server```
+
+## Usage
+
+Most basic usage is to simply pass the port that you want to run the server. It
+is important to not forget to construct the server without the ```new```
+keyword, unless global access to the redis-server properties is required.
+
+```javascript
+
+var RedisServer = require('redis-server');
+var redisServerInstance = new RedisServer(6379);
+
+redisServerInstance.open(function (error) {
+
+  if (error) {
+    throw new Error(error);
+  }
+
+  // The server is now up and running on port 6379,
+  // you can now create a client to connect to the
+  // server
+
+});
+
+```
+
 ## TODO
+
 more tests/documentation!

--- a/redis-server.js
+++ b/redis-server.js
@@ -4,7 +4,14 @@ var childProcess = require('child_process')
   , keyRE = /(port:\s+\d+)|(pid:\s+\d+)|(already\s+in\s+use)|(not\s+listen)|error|denied/ig
   , strRE = / /ig;
 
+var DEFAULT_PORT = 6379;
+
 function RedisServer(configOrPort) {
+    
+    if (typeof configOrPort === 'undefined') {
+        configOrPort = DEFAULT_PORT;
+    }
+    
     this.config = typeof configOrPort === 'number' ? { port: configOrPort } : (configOrPort || {});
     this.pid = null;
     this.port = null;

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ var expect = require('expect.js')
 
 describe('redis-server', function () {
     var port = Math.floor(Math.random() * 10000) + 9000
-      , server1, server2;
+      , server1, server2, server3;
 
     it('should start a server', function (done) {
         server1 = new RedisServer({ port: port });
@@ -118,5 +118,31 @@ describe('redis-server', function () {
         expect(server2.isRunning).to.be(false);
         expect(server2.isClosing).to.be(false);
         expect(server2.process).to.be(null);
+    });
+    it('should start a server with no config provided', function(done) {
+        server3 = new RedisServer();       
+
+        expect(server3.pid).to.be(null);
+        expect(server3.port).to.be(null);
+        expect(server3.process).to.be(null);
+        expect(server3.isOpening).to.be(false);
+        expect(server3.isClosing).to.be(false);
+        expect(server3.open(done)).to.be(true);
+        expect(server3.isOpening).to.be(true);
+    });
+    it('should use port 6379 when no config is provided', function () {
+        expect(server3.isOpening).to.be(false);
+        expect(server3.isRunning).to.be(true);
+        expect(server3.isClosing).to.be(false);
+        expect(server3.pid).to.be.a('number');
+        expect(server3.port).to.be(6379);
+        expect(server3.process).to.not.be(null);
+    });
+    it('should stop a server with no config', function (done) {
+        expect(server3.isOpening).to.be(false);
+        expect(server3.isRunning).to.be(true);
+        expect(server3.isClosing).to.be(false);
+        expect(server3.close(done)).to.be(true);
+        expect(server3.isClosing).to.be(true);
     });
 });


### PR DESCRIPTION
- README is now lint free (at least according to this https://githubcom/mivok/markdownlint)

- Added basic usage section with some simple sample code to get an instance of the server started