### PR TITLE
Added maxclients options and included it in all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ server.open((err) => {
 
 ### Configuration
 
-| Property | Type   | Default      | Description
-|:---------|:-------|:-------------|:-----------
-| bin      | String | redis-server | A Redis server binary path.
-| conf     | String |              | A Redis server configuration file path.
-| port     | Number | 6379         | A port to bind a Redis server to.
-| slaveof  | String |              | An address of a Redis server to sync with.
+| Property  | Type   | Default      | Description
+|:----------|:-------|:-------------|:-----------
+| bin       | String | redis-server | A Redis server binary path.
+| conf      | String |              | A Redis server configuration file path.
+| port      | Number | 6379         | A port to bind a Redis server to.
+| slaveof   | String |              | An address of a Redis server to sync with.
+| maxclients| Number |              | Maximum number of clients.
 
 A Redis server binary must be available. If you do not have one in $PATH,
 provide a path in configuration.

--- a/RedisServer.js
+++ b/RedisServer.js
@@ -97,6 +97,10 @@ class RedisServer extends events.EventEmitter {
       target.port = source.port;
     }
 
+    if (source.maxclients != null) {
+      target.maxclients = source.maxclients;
+    }
+
     return target;
   }
 
@@ -119,6 +123,10 @@ class RedisServer extends events.EventEmitter {
 
     if (config.slaveof != null) {
       flags.push(`--slaveof ${config.slaveof}`);
+    }
+
+    if (config.maxclients != null) {
+      flags.push(`--maxclients ${config.maxclients}`);
     }
 
     return flags;
@@ -324,7 +332,8 @@ class RedisServer extends events.EventEmitter {
       bin: 'redis-server',
       conf: null,
       port: 6379,
-      slaveof: null
+      slaveof: null,
+      maxclients: null
     });
 
     /**


### PR DESCRIPTION
Hello,

So, I was trying out some modifications, tried to run the tests, and a lot of them (any test who actually launched `redis` was failing). Took me a while to understand what was going on, but it has to do with:

```
16981:C 30 Apr 22:00:38.397 # Redis version=4.0.9, bits=64, commit=00000000, modified=0, pid=16981, just started
16981:C 30 Apr 22:00:38.397 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
16981:M 30 Apr 22:00:38.400 # You requested maxclients of 10000 requiring at least 10032 max file descriptors.
16981:M 30 Apr 22:00:38.400 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
16981:M 30 Apr 22:00:38.400 # Current maximum open files is 4096. maxclients has been reduced to 4064 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
 ```

Of course properly configured production machines will have these settings adjusted globally, either by `ulimit -n` or by setting `systemd` settings, but I think this is not strictly necessary on the developers machine running the tests.

So, I've managed to run the tests successfully defining the `redis` `maxclients` options instead, which I added to the code (first part of my PR).

But then, we either define a default value of 4096 and no changes to the tests are needed - but this is imposing an artificial default which differs from `redis`, or we modify the tests to always include this new setting - I opted out by this last option, since it was the only way for  the tests to pass on my machine.

It's a bit more verbose, but I'm guessing it should have no impact on machines where this was not a problem.

Let me know what you think, I may have other (smaller) PRs on the pipeline.
Thanks