### PR TITLE
Exit event

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Emitted when attempting to stop a Redis server.
 #### close
 
 Emitted once a Redis server has stopped. This only happens when `server.closed` is called,
-not when the `child_process` exits on it's own.
+not when the `child_process` fails on it's own (`redis-server` not found, for example).
 
 #### exiting
 

--- a/README.md
+++ b/README.md
@@ -167,4 +167,13 @@ Emitted when attempting to stop a Redis server.
 
 #### close
 
-Emitted once a Redis server has stopped.
+Emitted once a Redis server has stopped. This only happens when `server.closed` is called,
+not when the `child_process` exits on it's own.
+
+#### exiting
+
+Emmited when a Redis server is exiting or `child_process` exits with an error.
+
+#### exit
+
+Emmited when a Redis server exited (and `server.closed` was called).

--- a/RedisServer.js
+++ b/RedisServer.js
@@ -243,11 +243,17 @@ class RedisServer extends events.EventEmitter {
 
         /**
          * A listener to close the server when the current process exits.
+         * For the parameter list, please consult:
+         * https://nodejs.org/api/child_process.html#child_process_event_exit
+         * @argument {Number} [exitCode] final process exit code
+         * @argument {String} [signal] The signal by which the redis was terminated
          * @return {undefined}
          */
-        const exitListener = () => {
+        const exitListener = (exitCode, signal) => {
+          server.emit('exiting', { exitCode, signal });
           // istanbul ignore next
           server.close();
+          server.emit('exit', { exitCode, signal });
         };
 
         server.emit('opening');

--- a/RedisServer.js
+++ b/RedisServer.js
@@ -236,7 +236,7 @@ class RedisServer extends events.EventEmitter {
           else {
             server.isClosing = true;
 
-            server.emit('closing');
+            server.emit('closing', result.err);
             server.process.once('close', () => reject(result.err));
           }
         };


### PR DESCRIPTION
When `redis` is not installed, no event is called (namely `close`). Hence, this PR adds the `exiting` and `exit` events, which pass the `exitCode` and allow the developer to identify if there was a problem launching `redis`.

Also, when calling `closing`, pass the `result.err` to allow the user code to identify any possible error when parsing the configuration.

What do you think?
Thanks