### PR TITLE
fix: Do not quote spawn args on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+  - windows
 language: node_js
 node_js:
 - '4.2'

--- a/RedisServer.js
+++ b/RedisServer.js
@@ -269,7 +269,10 @@ class RedisServer extends events.EventEmitter {
 
         server.process = childprocess.spawn(
           server.config.bin,
-          RedisServer.parseFlags(server.config)
+          RedisServer.parseFlags(server.config),
+          {
+            windowsVerbatimArguments: true // Do not quote the flags
+          }
         );
 
         server.process.stdout.on('data', dataListener);


### PR DESCRIPTION
Without setting `windowsVerbatimArguments: true` in the
spawn options the redis-server would be spawned with
`redis-server.exe "--port 3679"` which it would not accept as a valid argument.